### PR TITLE
Update DownloadManifestService.cs

### DIFF
--- a/Services/DownloadManifestService.cs
+++ b/Services/DownloadManifestService.cs
@@ -74,6 +74,7 @@ namespace Destiny2.Services
 
     private async Task<string> GetCurrentManifestVersion(CancellationToken cancellationToken)
     {
+        _manifestSettings.VersionPath.Refresh();
         if (!_manifestSettings.VersionPath.Exists)
         {
             _logger?.LogInformation("VersionPath doesn't exist. Returning an empty string.");


### PR DESCRIPTION
I noticed if the destinymanifest doesn't exist when the service starts up, it repeatedly downloads the manifest. I believe this is because the FileInfo for the VersionPath is stale and needs to be refreshed after the file is written.

